### PR TITLE
Homework5 - Fixed EditMenuItem Form adding missing props

### DIFF
--- a/src/components/menu-items/item/controls/EditMenuItem.tsx
+++ b/src/components/menu-items/item/controls/EditMenuItem.tsx
@@ -45,7 +45,7 @@ const EditMenuItem = (props: {
       </button>
       <Modal isOpen={isModalOpen} close={modalCloseHandler}>
         <h2 className="title-style d-flex">Edit Menu Item</h2>
-        <MenuItemForm onSubmit={submitHandler} />
+        <MenuItemForm menuItem={props.item} onSubmit={submitHandler} />
       </Modal>
     </div>
   )


### PR DESCRIPTION
Searching through the code, we noticed that we were not sending the item to MenuItemForm and for this reason it did not appear in the from either. 